### PR TITLE
Properly center HUD on iPad in split screen

### DIFF
--- a/ProgressHUD/Sources/ProgressHUD.swift
+++ b/ProgressHUD/Sources/ProgressHUD.swift
@@ -532,7 +532,8 @@ public class ProgressHUD: UIView {
 			heightKeyboard = keyboardHeight()
 		}
 
-		let screen = UIScreen.main.bounds
+		let mainWindow = UIApplication.shared.windows.first ?? UIWindow()
+		let screen = mainWindow.bounds
 		let center = CGPoint(x: screen.size.width/2, y: (screen.size.height-heightKeyboard)/2)
 
 		UIView.animate(withDuration: animationDuration, delay: 0, options: .allowUserInteraction, animations: {

--- a/ProgressHUD/app/Info.plist
+++ b/ProgressHUD/app/Info.plist
@@ -35,6 +35,7 @@
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
This PR fixes an issue where the HUD didn't appear correctly centered on iPad when in split screen.
Tested on iOS 13 and 14.

I also added support for split screen on iPad in the demo app by adding support for Device orientation: `UIInterfaceOrientationPortraitUpsideDown`.

<img width="1166" alt="Screen Shot 2021-04-05 at 3 07 41 PM" src="https://user-images.githubusercontent.com/240599/113615023-55a69600-9621-11eb-9166-3e9417bed700.png">
