### PR TITLE
Add default localization in package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "ProgressHUD",
+    defaultLocalization: "en",
     platforms: [
         .iOS(.v13),
     ],


### PR DESCRIPTION
Add default localization to the Swift Package file.
Links:
https://stackoverflow.com/questions/67871929/swift-package-manifest-property-defaultlocalization-not-set