### PR TITLE
Fix paths in package manifests, and use process rule for privacy manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,10 +18,9 @@ let package = Package(
         .target(
             name: "ProgressHUD",
             dependencies: [],
-            path: "./ProgressHUD",
-            sources: ["Sources"],
+            path: "ProgressHUD/Sources",
             resources: [
-                .copy("PrivacyInfo.xcprivacy")
+                .process("PrivacyInfo.xcprivacy"),
             ]
         ),
     ]


### PR DESCRIPTION
When building my app, I get the following warning.

`no rule to process file 'ProgressHUD/Sources/PrivacyInfo.xcprivacy' of type 'file' for architecture 'x86_64'`

If you change the resource rule in the manifest to `process` you get a more informative warning.

`Invalid Resource 'PrivacyInfo.xcprivacy': File not found.`

The actual issue seemed to be that the path is incorrect. However, after changing the path to `Sources/PrivacyInfo.xcprivacy` we get an error now instead of a warning.

`duplicate rule found for file at 'ProgressHUD/Sources/PrivacyInfo.xcprivacy'`

What's going on here is that the different path parameters for a target interact in unintuitive ways when it comes to resolving paths in a package. I don't want to write it all out here (I should put it in a blog post instead), but the bottom line is that you want to specify the complete path to the target sources in the `path` parameter, and then specify a `process` rule for the primary manifest with a path relative to the sources directory. 

This PR addresses this issue, and also prevents some unintended files from the `app` directory from being included in the library.

Output of `swift package describe` before:

```
warning: 'progresshud': Invalid Resource 'PrivacyInfo.xcprivacy': File not found.
Name: ProgressHUD
Manifest display name: ProgressHUD
Path: ~/openSource/ProgressHUD
Tools version: 5.3
Dependencies:
Default localization: en
Platforms:
    Name: ios
    Version: 13.0

Products:
    Name: ProgressHUD
    Type:
        Library:
            automatic
    Targets:
        ProgressHUD

Targets:
    Name: ProgressHUD
    Type: library
    C99name: ProgressHUD
    Module type: SwiftTarget
    Path: ProgressHUD
    Sources:
        Sources/Animations/ProgressHUD+ActivityIndicator.swift
        Sources/Animations/ProgressHUD+BallVerticalBounce.swift
        Sources/Animations/ProgressHUD+BarSweepToggle.swift
        Sources/Animations/ProgressHUD+CircleArcDotSpin.swift
        Sources/Animations/ProgressHUD+CircleBarSpinFade.swift
        Sources/Animations/ProgressHUD+CircleDotSpinFade.swift
        Sources/Animations/ProgressHUD+CirclePulseMultiple.swift
        Sources/Animations/ProgressHUD+CirclePulseSingle.swift
        Sources/Animations/ProgressHUD+CircleRippleMultiple.swift
        Sources/Animations/ProgressHUD+CircleRippleSingle.swift
        Sources/Animations/ProgressHUD+CircleRotateChase.swift
        Sources/Animations/ProgressHUD+CircleStrokeSpin.swift
        Sources/Animations/ProgressHUD+DualDotSidestep.swift
        Sources/Animations/ProgressHUD+HorizontalBarScaling.swift
        Sources/Animations/ProgressHUD+HorizontalDotScaling.swift
        Sources/Animations/ProgressHUD+PacmanProgress.swift
        Sources/Animations/ProgressHUD+QuintupleDotDance.swift
        Sources/Animations/ProgressHUD+SFSymbolBounce.swift
        Sources/Animations/ProgressHUD+SemiRingRotation.swift
        Sources/Animations/ProgressHUD+SquareCircuitSnake.swift
        Sources/Animations/ProgressHUD+TriangleDotShift.swift
        Sources/PrivacyInfo.xcprivacy
        Sources/ProgressHUD+Banner.swift
        Sources/ProgressHUD+Enums.swift
        Sources/ProgressHUD+LiveIcon.swift
        Sources/ProgressHUD+Public.swift
        Sources/ProgressHUD.swift
        Sources/ProgressView.swift
    Resources:
        Rule:
            Process:
        Path:
            ~/openSource/ProgressHUD/ProgressHUD/app/Assets.xcassets
        Rule:
            Process:
                Localization: Base
        Path:
            ~/openSource/ProgressHUD/ProgressHUD/app/Base.lproj/LaunchScreen.storyboard
        Rule:
            Process:
        Path:
            ~/openSource/ProgressHUD/ProgressHUD/app/ViewController.xib
    Product memberships:
        ProgressHUD
```

After:

```
Name: ProgressHUD
Manifest display name: ProgressHUD
Path: ~/openSource/ProgressHUD
Tools version: 5.3
Dependencies:
Default localization: en
Platforms:
    Name: ios
    Version: 13.0

Products:
    Name: ProgressHUD
    Type:
        Library:
            automatic
    Targets:
        ProgressHUD

Targets:
    Name: ProgressHUD
    Type: library
    C99name: ProgressHUD
    Module type: SwiftTarget
    Path: ProgressHUD/Sources
    Sources:
        Animations/ProgressHUD+ActivityIndicator.swift
        Animations/ProgressHUD+BallVerticalBounce.swift
        Animations/ProgressHUD+BarSweepToggle.swift
        Animations/ProgressHUD+CircleArcDotSpin.swift
        Animations/ProgressHUD+CircleBarSpinFade.swift
        Animations/ProgressHUD+CircleDotSpinFade.swift
        Animations/ProgressHUD+CirclePulseMultiple.swift
        Animations/ProgressHUD+CirclePulseSingle.swift
        Animations/ProgressHUD+CircleRippleMultiple.swift
        Animations/ProgressHUD+CircleRippleSingle.swift
        Animations/ProgressHUD+CircleRotateChase.swift
        Animations/ProgressHUD+CircleStrokeSpin.swift
        Animations/ProgressHUD+DualDotSidestep.swift
        Animations/ProgressHUD+HorizontalBarScaling.swift
        Animations/ProgressHUD+HorizontalDotScaling.swift
        Animations/ProgressHUD+PacmanProgress.swift
        Animations/ProgressHUD+QuintupleDotDance.swift
        Animations/ProgressHUD+SFSymbolBounce.swift
        Animations/ProgressHUD+SemiRingRotation.swift
        Animations/ProgressHUD+SquareCircuitSnake.swift
        Animations/ProgressHUD+TriangleDotShift.swift
        ProgressHUD+Banner.swift
        ProgressHUD+Enums.swift
        ProgressHUD+LiveIcon.swift
        ProgressHUD+Public.swift
        ProgressHUD.swift
        ProgressView.swift
    Resources:
        Rule:
            Process:
        Path:
            ~/openSource/ProgressHUD/ProgressHUD/Sources/PrivacyInfo.xcprivacy
    Product memberships:
        ProgressHUD
```