### PR TITLE
Allow observation of attribute

### DIFF
--- a/SwiftUI/Sources/ProgressHUD.swift
+++ b/SwiftUI/Sources/ProgressHUD.swift
@@ -27,7 +27,7 @@ public class ProgressHUD {
 	// MARK: - Properties
 	public static let shared = ProgressHUD()
 
-	var isVisible = false
+	public internal(set) var isVisible = false
 	var text: String?
 	var displayMode = DisplayMode.animation
 


### PR DESCRIPTION
I would like to clear some app state when the current HUD display goes away. If this attribute is visible then I can use it in an `onChange` view modifier. I'm sure I could work around not having it, but this seemed to be the cleanest and simplest way to make it happen. Thoughts?